### PR TITLE
which to locate linux firefox bin

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,7 @@ var path = require("path");
 var os = require("os");
 var Winreg = require('winreg');
 var when = require("when");
+var which = require("which");
 
 /**
  * Takes a path to a binary file (like `/Applications/FirefoxNightly.app`)
@@ -107,12 +108,12 @@ normalizeBinary.paths = {
   "aurora on osx": "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin",
   "nightly on osx": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin",
 
-  "firefox on linux": "/usr/lib/firefox",
+  "firefox on linux": which.sync("firefox"),
   "beta on linux": "/usr/lib/firefox-beta",
   "aurora on linux": "/usr/lib/firefox-aurora",
   "nightly on linux": "/usr/lib/firefox-nightly",
 
-  "firefox on linux(64)": "/usr/lib64/firefox",
+  "firefox on linux(64)": which.sync("firefox"),
   "beta on linux(64)": "/usr/lib64/firefox-beta",
   "aurora on linux(64)": "/usr/lib64/firefox-aurora",
   "nightly on linux(64)" : "/usr/lib64/firefox-nightly"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chai": "1.10.0",
     "dive": "0.3.1",
     "mocha": "2.1.0",
-    "sandboxed-module": "2.0.0"
+    "sandboxed-module": "2.0.0",
+    "which": "^1.1.1"
   }
 }


### PR DESCRIPTION
Fixes #4 - note that in its current state it makes a few assumptions:

- User has firefox installed (`which.sync` will throw an error otherwise)
- User doesn't really care about other versions of firefox (beta, aurora, nightly)

The `which` technique could be extended to those other versions of Firefox, but it would be bad to use the sync version in that case (as it's much less safe to assume everyone has those installed). This is definitely doable, but would be a bigger change in the logic/flow of this module, so I want to get initial thoughts on this change first (which I think solves the far more common use case).